### PR TITLE
Hashtag-Emoji-Bug

### DIFF
--- a/GetOldTweets3/manager/TweetManager.py
+++ b/GetOldTweets3/manager/TweetManager.py
@@ -187,13 +187,16 @@ class TweetManager:
             html = match.group(4)
 
             attr = TweetManager.parse_attributes(link)
-            if "u-hidden" in attr["class"]:
+            try:   
+                if "u-hidden" in attr["class"]:
+                    pass
+                elif "data-expanded-url" in attr \
+                and "twitter-timeline-link" in attr["class"]:
+                    text += attr['data-expanded-url']
+                else:
+                    text += link
+            except:
                 pass
-            elif "data-expanded-url" in attr \
-               and "twitter-timeline-link" in attr["class"]:
-                text += attr['data-expanded-url']
-            else:
-                text += link
 
             match = are.match(html)
         text = text + html


### PR DESCRIPTION
Fixed: TwitterManager was not able to process tweets with hashtags that Twitter automatically attaches an emoji (e.g. #MyTwitterAnniversary)

I added a try/except block to catch following error and ignore the automatically added emoji:
```
File "/Users/Jham/src/getoldtweets3/GetOldTweets3/manager/TweetManager.py", line 88, in getTweets
rawtext = TweetManager.textify(tweetPQ("p.js-tweet-text").html(), tweetCriteria.emoji)
File "/Users/Jham/src/getoldtweets3/GetOldTweets3/manager/TweetManager.py", line 190, in textify
if "u-hidden" in attr["class"]:
KeyError: 'class'
```
Maybe there is a more elegant solution but it works.