### PR TITLE
Implemented NoneType check for html parameter

### DIFF
--- a/GetOldTweets3/manager/TweetManager.py
+++ b/GetOldTweets3/manager/TweetManager.py
@@ -173,6 +173,12 @@ class TweetManager:
         emoji images with appropriate emoji markup, replace links with the original
         URIs, and discard all other markup.
         """
+        
+        # Chech if value is passed by the html parameter - otherwise set empty string to prevent error
+        if html is None:
+            html = ''
+        
+        
         # Step 0, compile some convenient regular expressions
         imgre = re.compile("^(.*?)(<img.*?/>)(.*)$")
         charre = re.compile("^&#x([^;]+);(.*)$")


### PR DESCRIPTION
Parameter html was assumed to be type of string. This is not always the case, therefore a check is implemented to prevent the application from crashing

I executed the following code and after a while it threw an error because the html parameter did not have the proper type.

tweetCriteria = got.manager.TweetCriteria().setQuerySearch('SEZ').setEmoji("unicode")
 tweets = got.manager.TweetManager.getTweets(tweetCriteria)

Thrown Error:

---------------------------------------------------------------------------

AttributeError                            Traceback (most recent call last)

<ipython-input-22-c00423c7aa80> in <module>()
     45 for st in searchterms:
     46   tweetCriteria = got.manager.TweetCriteria().setQuerySearch(st).setEmoji("unicode")
---> 47   tweets = got.manager.TweetManager.getTweets(tweetCriteria)
     48   ct = ct + 1
     49   print('st number ' + str(ct))

1 frames

/usr/local/lib/python3.6/dist-packages/GetOldTweets3/manager/TweetManager.py in getTweets(tweetCriteria, receiveBuffer, bufferLength, proxy, debug)
     86                     tweet.username = usernames[0]
     87                     tweet.to = usernames[1] if len(usernames) >= 2 else None  # take the first recipient if many
---> 88                     rawtext = TweetManager.textify(tweetPQ("p.js-tweet-text").html(), tweetCriteria.emoji)
     89                     tweet.text = re.sub(r"\s+", " ", rawtext)\
     90                         .replace('# ', '#').replace('@ ', '@').replace('$ ', '$')

/usr/local/lib/python3.6/dist-packages/GetOldTweets3/manager/TweetManager.py in textify(html, emoji)
    182         # Step 1, prepare a single-line string for re convenience
    183         puc = chr(0xE001)
--> 184         html = html.replace("\n", puc)
    185 
    186         # Step 2, find images that represent emoji, replace them with the

AttributeError: 'NoneType' object has no attribute 'replace'