### PR TITLE
implement a simple rate limit 

### DIFF
--- a/GetOldTweets3/manager/TweetManager.py
+++ b/GetOldTweets3/manager/TweetManager.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
+import time # to implement a simple rate limit
+
 import json, re, datetime, sys, random, http.cookiejar
 import urllib.request, urllib.parse, urllib.error
 from pyquery import PyQuery
@@ -342,6 +346,15 @@ class TweetManager:
         try:
             response = opener.open(url)
             jsonResponse = response.read()
+            # Hack for rate limits START
+        except urllib.error.HTTPError as e:
+            if e.code == 429:
+                print("\n Recieved error code 429 from Twitter, sleeping 15 minutes to avoid rate limit errors.")
+                time.sleep(900);
+                print("Awakening")
+                response = opener.open(url)
+                jsonResponse = response.read()
+                # Hack for rate limits STOP
         except Exception as e:
             print("An error occured during an HTTP request:", str(e))
             print("Try to open in browser: https://twitter.com/search?q=%s&src=typd" % urllib.parse.quote(urlGetData))


### PR DESCRIPTION
This simple rate limit implementation pauses 15 minutes after receiving http error code 429 'too many requests'.

It is based on code posted in response to issue #57 https://github.com/Mottl/GetOldTweets3/issues/57
