### PR TITLE
Do not call sys.exit when the library encounters an error (!)

### DIFF
--- a/GetOldTweets3/__init__.py
+++ b/GetOldTweets3/__init__.py
@@ -1,4 +1,4 @@
 from . import models
 from . import manager
 
-__version__ = '0.0.11'
+__version__ = '0.0.12'

--- a/GetOldTweets3/manager/TweetManager.py
+++ b/GetOldTweets3/manager/TweetManager.py
@@ -118,7 +118,7 @@ class TweetManager:
 
                     results.append(tweet)
                     resultsAux.append(tweet)
-                    
+
                     if receiveBuffer and len(resultsAux) >= bufferLength:
                         receiveBuffer(resultsAux)
                         resultsAux = []
@@ -134,7 +134,7 @@ class TweetManager:
 
         return results
 
-    @staticmethod 
+    @staticmethod
     def getHashtagsAndMentions(tweetPQ):
         """Given a PyQuery instance of a tweet (tweetPQ) getHashtagsAndMentions
         gets the hashtags and mentions from a tweet using the tweet's
@@ -153,7 +153,7 @@ class TweetManager:
                 continue
 
             # Mention anchor tags have a data-mentioned-user-id
-            # attribute. 
+            # attribute.
             if not tagPQ.attr("data-mentioned-user-id") is None:
                 mentions.append("@" + url[1:])
                 continue
@@ -219,7 +219,7 @@ class TweetManager:
             html = match.group(4)
 
             attr = TweetManager.parse_attributes(link)
-            try:   
+            try:
                 if "u-hidden" in attr["class"]:
                     pass
                 elif "data-expanded-url" in attr \
@@ -351,25 +351,10 @@ class TweetManager:
             print(url)
             print('\n'.join(h[0]+': '+h[1] for h in headers))
 
-        try:
-            response = opener.open(url)
-            jsonResponse = response.read()
-        except Exception as e:
-            print("An error occured during an HTTP request:", str(e))
-            print("Try to open in browser: https://twitter.com/search?q=%s&src=typd" % urllib.parse.quote(urlGetData))
-            sys.exit()
-
-        try:
-            s_json = jsonResponse.decode()
-        except:
-            print("Invalid response from Twitter")
-            sys.exit()
-
-        try:
-            dataJson = json.loads(s_json)
-        except:
-            print("Error parsing JSON: %s" % s_json)
-            sys.exit()
+        response = opener.open(url)
+        jsonResponse = response.read()
+        s_json = jsonResponse.decode()
+        dataJson = json.loads(s_json)
 
         if debug:
             print(s_json)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fh:
 
 setuptools.setup(
     name="GetOldTweets3",
-    version="0.0.11",
+    version="0.0.12",
     author="Dmitry Mottl",
     author_email="dmitry.mottl@gmail.com",
     license='MIT',


### PR DESCRIPTION
The code removed is an example how to write bad Python.
Blanket exception catching is bad. Exiting the whole application is atrocious, because it makes it impossible to handle errors. Exiting the whole application with `EXIT_SUCCESS` is a horror.

Besides, cleanup some whitespace.

Closes #67.